### PR TITLE
issue #265: removes dependency on the LD_LIBRARY_PATH environment variable

### DIFF
--- a/libxulsword/binding.gyp
+++ b/libxulsword/binding.gyp
@@ -3,7 +3,7 @@
     {
       "target_name": "libxulsword",
       "sources": [ "src/libxulsword.cpp" ],
-      "libraries": ["${LD_LIBRARY_PATH}/libxulsword.so.1.4.4"],
+      "libraries": ["../../../../../Cpp/build/libxulsword.so.1.4.4"],
       "include_dirs": [
         "<!@(node -p \"require('node-addon-api').include\")",
         "../../../../Cpp/src/include",


### PR DESCRIPTION
Build now successfully completes without reliance on the LD_LIBRARY_PATH environment variable.  I'm not sure what (if any) packaging issues this change may result in ... I believe none but we'll soon see.  :-)