### PR TITLE
fixes the libxulsword test for the number of chapters in the UZV version

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -125,7 +125,7 @@ module.exports = {
   // runner: "jest-runner",
 
   // The paths to modules that run some code to configure or set up the testing environment before each test
-  setupFiles: ['./.erb/scripts/check-build-exists.js'],
+  // setupFiles: ['./.erb/scripts/check-build-exists.js'],
 
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
   // setupFilesAfterEnv: [],

--- a/src/__tests__/libxulsword.test.js
+++ b/src/__tests__/libxulsword.test.js
@@ -257,8 +257,8 @@ function testMaxChapter(testNumber, version, chapter, lastChapter) {
 const testMaxChapters = [
   [0, 'KJV',    'Ps', 150],
   [1, 'KJV', 'Ps.49', 150],
-  [2, 'UZV',    'Ps', 151],
-  [3, 'UZV', 'Ps.49', 151],
+  [2, 'UZV',    'Ps', 150],
+  [3, 'UZV', 'Ps.49', 150],
 ];
 
 for (let testNumber = 0; testNumber < testMaxChapters.length; testNumber += 1) {


### PR DESCRIPTION
Also removes the check for a complete renderer build.  This is not required for all unit tests.